### PR TITLE
Adding <no-ssr>

### DIFF
--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -43,10 +43,12 @@
       </div>
     </div>
     <div class="container small">
-      <DynamicMarkdown
-        :render-func="renderFunc"
-        :static-render-funcs="staticRenderFuncs"
-        :extra-component="extraComponent" />
+      <no-ssr>
+        <DynamicMarkdown
+          :render-func="renderFunc"
+          :static-render-funcs="staticRenderFuncs"
+          :extra-component="extraComponent" />
+      </no-ssr>
     </div>
     <Subscribe/>
   </div>


### PR DESCRIPTION
According to [Kengo Hamasaki](https://medium.com/haiiro-io/compile-markdown-as-vue-template-on-nuxt-js-1c606c15731c), **no-ssr** is required to compile the HTML dynamically. This would fix #1